### PR TITLE
Feature/last login notice

### DIFF
--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -384,22 +384,7 @@ class login_security_solution {
 	 * @return int|bool  the record number if added, TRUE if updated, FALSE
 	 *                   if error
 	 */
-	public function add_to_message_queue($message) {
-		global $user_ID, $user_name;
-
-		if (empty($user_ID)) {
-			if (empty($user_name)) {
-				###$this->log(__FUNCTION__, "empty user_ID, user_name");
-				return;
-			}
-			$user = get_user_by('login', $user_name);
-			if (! $user instanceof WP_User) {
-				###$this->log(__FUNCTION__, "unknown user_name");
-				return -1;
-			}
-			$user_ID = $user->ID;
-		}
-
+	public function add_to_message_queue($message, $user_ID) {
 		$message_queue = $this->get_message_queue($user_ID);
 		$message_queue[] = $message;
 		###$this->log(__FUNCTION__, var_export($message_queue, true));
@@ -844,7 +829,7 @@ class login_security_solution {
 		$date_value  = date_i18n( "F j, Y g:i a T", $last_login, true );
 		$message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
 		###$this->log(__FUNCTION__, $message);
-		$this->add_to_message_queue($message);
+		$this->add_to_message_queue($message, $user_ID);
 		return $this->set_last_login($user_ID);
 	}
 

--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -207,6 +207,18 @@ class login_security_solution {
 	 */
 	protected $umk_last_active;
 
+    /**
+     * Our usermeta key for tracking when the user last logged in
+     * @var string
+     */
+    protected $umk_last_login;
+
+    /**
+     * Our usermeta key for tracking messages
+     * @var array
+     */
+    protected $umk_message_queue;
+
 	/**
 	 * Our usermeta key for tracking if a user's password needs to be changed
 	 * @var string
@@ -242,6 +254,7 @@ class login_security_solution {
 	public function __construct() {
 		$this->initialize();
 
+        add_action('admin_notices', array(&$this, 'display_admin_notices_in_queue'));
 		add_action('auth_cookie_bad_username', array(&$this, 'auth_cookie_bad'));
 		add_action('auth_cookie_bad_hash', array(&$this, 'auth_cookie_bad'));
 		add_action('auth_cookie_valid', array(&$this, 'check'), 1, 2);
@@ -332,6 +345,8 @@ class login_security_solution {
 		$this->umk_grace_period = self::ID . '-pw-grace-period-start-time';
 		$this->umk_hashes = self::ID . '-pw-hashes';
 		$this->umk_last_active = self::ID . '-last-active';
+        $this->umk_last_login = self::ID . '-last-login';
+        $this->umk_message_queue = self::ID . '-message-queue';
 		$this->umk_verified_ips = self::ID . '-verified-ips';
 
 		$this->dir_dictionaries = dirname(__FILE__) . '/pw_dictionaries/';
@@ -361,6 +376,36 @@ class login_security_solution {
 	/*
 	 * ===== ACTION & FILTER CALLBACK METHODS =====
 	 */
+
+
+    /**
+     * Adds a new message to a users message queue
+     *
+     * @return int|bool  the record number if added, TRUE if updated, FALSE
+     *                   if error
+     */
+    public function add_to_message_queue($message) {
+        global $user_ID, $user_name;
+
+        if (empty($user_ID)) {
+            if (empty($user_name)) {
+                ###$this->log(__FUNCTION__, "empty user_ID, user_name");
+                return;
+            }
+            $user = get_user_by('login', $user_name);
+            if (! $user instanceof WP_User) {
+                ###$this->log(__FUNCTION__, "unknown user_name");
+                return -1;
+            }
+            $user_ID = $user->ID;
+        }
+
+        $message_queue = $this->get_message_queue($user_ID);
+        $message_queue[] = $message;
+        ###$this->log(__FUNCTION__, var_export($message_queue, true));
+
+        return update_user_meta($user_ID, $this->umk_message_queue, $message_queue);
+    }
 
 	/**
 	 * Sends failed auth cookie data to our login failure process
@@ -596,6 +641,45 @@ class login_security_solution {
 		return delete_user_meta($user_ID, $this->umk_last_active);
 	}
 
+    /**
+     * Produces a notice at the top of each admin page, depending on the messages
+     * in the admin_message_queue
+     *
+     * @return void
+     */
+    public function display_admin_notices_in_queue() {
+        global $user_ID, $user_name;
+
+        if (empty($user_ID)) {
+            if (empty($user_name)) {
+                ###$this->log(__FUNCTION__, "empty user_ID, user_name");
+                return;
+            }
+            $user = get_user_by('login', $user_name);
+            if (! $user instanceof WP_User) {
+                ###$this->log(__FUNCTION__, "unknown user_name");
+                return -1;
+            }
+            $user_ID = $user->ID;
+        }
+        $messages = $this->get_message_queue($user_ID);
+        $message_buffer = '';
+        ###$this->log(__FUNCTION__, var_export($messages, true));
+
+        if (!empty($messages)) {
+            foreach ($messages as $message) {
+                ###$this->log(__FUNCTION__, $message);
+                $message_buffer .= '<div class="updated"><p>'. $message . '</p></div>';
+            }
+        }
+
+        // Clear the message queue
+        delete_user_meta($user_ID, $this->umk_message_queue);
+
+        echo $message_buffer;
+        return $message_buffer;
+    }
+
 	/**
 	 * Alters the failure messages from logins and password resets that
 	 * contain information disclosures
@@ -748,6 +832,21 @@ class login_security_solution {
 		$this->save_verified_ip($user->ID, $this->get_ip());
 		$this->process_pw_metadata($user->ID, $user_pass);
 	}
+
+    /**
+     * Adds new last login message to users message queue
+     *
+     * @param int $user_ID  the current user's ID number
+     * @return mixed  return values provided for unit testing
+     */
+    public function push_last_login_to_message_queue($user_ID) {
+        $last_login = $this->get_last_login($user_ID) ?: time();
+        $date_value  = date_i18n( "F j, Y g:i a T", $last_login, true );
+        $message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
+        ###$this->log(__FUNCTION__, $message);
+        $this->add_to_message_queue($message);
+        return $this->set_last_login($user_ID);
+    }
 
 	/**
 	 * Declares our password policy gettext filter and deactivates the
@@ -1074,6 +1173,17 @@ class login_security_solution {
 		return (int) get_user_meta($user_ID, $this->umk_last_active, true);
 	}
 
+    /**
+     * Obtains the timestamp of the given user's last login on the site
+     *
+     * @param int $user_ID  the current user's ID number
+     * @return int  the Unix timestamp of the user's last login
+     */
+    protected function get_last_login($user_ID) {
+        return (int) get_user_meta($user_ID, $this->umk_last_login, true);
+    }
+
+
 	/**
 	 * Obtains the number of login failures for the current IP, user name
 	 * and password in the period specified by login_fail_minutes
@@ -1130,6 +1240,21 @@ class login_security_solution {
 		###$this->log(__FUNCTION__, '', $result);
 		return $result;
 	}
+
+    /**
+     * Gets the users message queue
+     *
+     * return array the message queue
+     */
+    protected function get_message_queue($user_ID) {
+        $message_queue = get_user_meta($user_ID, $this->umk_message_queue, true);
+        if (empty($message_queue)) {
+            $message_queue = array();
+        } elseif (!is_array($message_queue)) {
+            $message_queue = (array) $message_queue;
+        }
+        return $message_queue;
+    }
 
 	/**
 	 * Gets the "network" component of an IP address
@@ -2307,6 +2432,8 @@ Password MD5                 %5d     %s
 			delete_user_meta($user->ID, $this->umk_last_active);
 		}
 
+        $this->push_last_login_to_message_queue($user->ID);
+
 		$flag = 1;
 		$ip = $this->get_ip();
 		$network_ip = $this->get_network_ip($ip);
@@ -2553,6 +2680,17 @@ Password MD5                 %5d     %s
 	protected function set_last_active($user_ID) {
 		return update_user_meta($user_ID, $this->umk_last_active, time());
 	}
+
+    /**
+     * Stores the present time in the given user's "last login" metadata
+     *
+     * @param int $user_ID  the current user's ID number
+     * @return int|bool  the record number if added, TRUE if updated, FALSE
+     *                   if error
+     */
+    protected function set_last_login($user_ID) {
+        return update_user_meta($user_ID, $this->umk_last_login, time());
+    }
 
 	/**
 	 * Replaces the default option values with those stored in the database

--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -826,7 +826,10 @@ class login_security_solution {
 	 */
 	public function push_last_login_to_message_queue($user_ID) {
 		$last_login = $this->get_last_login($user_ID) ?: time();
-		$date_value  = date_i18n( "F j, Y g:i a T", $last_login, true );
+		$tz_string = get_option('timezone_string');
+		date_default_timezone_set($tz_string);
+		$date_value  = date( "F j, Y g:i a T", $last_login);
+		date_default_timezone_set('UTC');
 		$message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
 		###$this->log(__FUNCTION__, $message);
 		$this->add_to_message_queue($message, $user_ID);

--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -207,17 +207,17 @@ class login_security_solution {
 	 */
 	protected $umk_last_active;
 
-    /**
-     * Our usermeta key for tracking when the user last logged in
-     * @var string
-     */
-    protected $umk_last_login;
+	/**
+	 * Our usermeta key for tracking when the user last logged in
+	 * @var string
+	 */
+	protected $umk_last_login;
 
-    /**
-     * Our usermeta key for tracking messages
-     * @var array
-     */
-    protected $umk_message_queue;
+	/**
+	 * Our usermeta key for tracking messages
+	 * @var array
+	 */
+	protected $umk_message_queue;
 
 	/**
 	 * Our usermeta key for tracking if a user's password needs to be changed
@@ -254,7 +254,7 @@ class login_security_solution {
 	public function __construct() {
 		$this->initialize();
 
-        add_action('admin_notices', array(&$this, 'display_admin_notices_in_queue'));
+		add_action('admin_notices', array(&$this, 'display_admin_notices_in_queue'));
 		add_action('auth_cookie_bad_username', array(&$this, 'auth_cookie_bad'));
 		add_action('auth_cookie_bad_hash', array(&$this, 'auth_cookie_bad'));
 		add_action('auth_cookie_valid', array(&$this, 'check'), 1, 2);
@@ -345,8 +345,8 @@ class login_security_solution {
 		$this->umk_grace_period = self::ID . '-pw-grace-period-start-time';
 		$this->umk_hashes = self::ID . '-pw-hashes';
 		$this->umk_last_active = self::ID . '-last-active';
-        $this->umk_last_login = self::ID . '-last-login';
-        $this->umk_message_queue = self::ID . '-message-queue';
+		$this->umk_last_login = self::ID . '-last-login';
+		$this->umk_message_queue = self::ID . '-message-queue';
 		$this->umk_verified_ips = self::ID . '-verified-ips';
 
 		$this->dir_dictionaries = dirname(__FILE__) . '/pw_dictionaries/';
@@ -378,34 +378,34 @@ class login_security_solution {
 	 */
 
 
-    /**
-     * Adds a new message to a users message queue
-     *
-     * @return int|bool  the record number if added, TRUE if updated, FALSE
-     *                   if error
-     */
-    public function add_to_message_queue($message) {
-        global $user_ID, $user_name;
+	/**
+	 * Adds a new message to a users message queue
+	 *
+	 * @return int|bool  the record number if added, TRUE if updated, FALSE
+	 *                   if error
+	 */
+	public function add_to_message_queue($message) {
+		global $user_ID, $user_name;
 
-        if (empty($user_ID)) {
-            if (empty($user_name)) {
-                ###$this->log(__FUNCTION__, "empty user_ID, user_name");
-                return;
-            }
-            $user = get_user_by('login', $user_name);
-            if (! $user instanceof WP_User) {
-                ###$this->log(__FUNCTION__, "unknown user_name");
-                return -1;
-            }
-            $user_ID = $user->ID;
-        }
+		if (empty($user_ID)) {
+			if (empty($user_name)) {
+				###$this->log(__FUNCTION__, "empty user_ID, user_name");
+				return;
+			}
+			$user = get_user_by('login', $user_name);
+			if (! $user instanceof WP_User) {
+				###$this->log(__FUNCTION__, "unknown user_name");
+				return -1;
+			}
+			$user_ID = $user->ID;
+		}
 
-        $message_queue = $this->get_message_queue($user_ID);
-        $message_queue[] = $message;
-        ###$this->log(__FUNCTION__, var_export($message_queue, true));
+		$message_queue = $this->get_message_queue($user_ID);
+		$message_queue[] = $message;
+		###$this->log(__FUNCTION__, var_export($message_queue, true));
 
-        return update_user_meta($user_ID, $this->umk_message_queue, $message_queue);
-    }
+		return update_user_meta($user_ID, $this->umk_message_queue, $message_queue);
+	}
 
 	/**
 	 * Sends failed auth cookie data to our login failure process
@@ -641,44 +641,44 @@ class login_security_solution {
 		return delete_user_meta($user_ID, $this->umk_last_active);
 	}
 
-    /**
-     * Produces a notice at the top of each admin page, depending on the messages
-     * in the admin_message_queue
-     *
-     * @return void
-     */
-    public function display_admin_notices_in_queue() {
-        global $user_ID, $user_name;
+	/**
+	 * Produces a notice at the top of each admin page, depending on the messages
+	 * in the admin_message_queue
+	 *
+	 * @return void
+	 */
+	public function display_admin_notices_in_queue() {
+		global $user_ID, $user_name;
 
-        if (empty($user_ID)) {
-            if (empty($user_name)) {
-                ###$this->log(__FUNCTION__, "empty user_ID, user_name");
-                return;
-            }
-            $user = get_user_by('login', $user_name);
-            if (! $user instanceof WP_User) {
-                ###$this->log(__FUNCTION__, "unknown user_name");
-                return -1;
-            }
-            $user_ID = $user->ID;
-        }
-        $messages = $this->get_message_queue($user_ID);
-        $message_buffer = '';
-        ###$this->log(__FUNCTION__, var_export($messages, true));
+		if (empty($user_ID)) {
+			if (empty($user_name)) {
+				###$this->log(__FUNCTION__, "empty user_ID, user_name");
+				return;
+			}
+			$user = get_user_by('login', $user_name);
+			if (! $user instanceof WP_User) {
+				###$this->log(__FUNCTION__, "unknown user_name");
+				return -1;
+			}
+			$user_ID = $user->ID;
+		}
+		$messages = $this->get_message_queue($user_ID);
+		$message_buffer = '';
+		###$this->log(__FUNCTION__, var_export($messages, true));
 
-        if (!empty($messages)) {
-            foreach ($messages as $message) {
-                ###$this->log(__FUNCTION__, $message);
-                $message_buffer .= '<div class="updated"><p>'. $message . '</p></div>';
-            }
-        }
+		if (!empty($messages)) {
+			foreach ($messages as $message) {
+				###$this->log(__FUNCTION__, $message);
+				$message_buffer .= '<div class="updated"><p>'. $message . '</p></div>';
+			}
+		}
 
-        // Clear the message queue
-        delete_user_meta($user_ID, $this->umk_message_queue);
+		// Clear the message queue
+		delete_user_meta($user_ID, $this->umk_message_queue);
 
-        echo $message_buffer;
-        return $message_buffer;
-    }
+		echo $message_buffer;
+		return $message_buffer;
+	}
 
 	/**
 	 * Alters the failure messages from logins and password resets that
@@ -833,20 +833,20 @@ class login_security_solution {
 		$this->process_pw_metadata($user->ID, $user_pass);
 	}
 
-    /**
-     * Adds new last login message to users message queue
-     *
-     * @param int $user_ID  the current user's ID number
-     * @return mixed  return values provided for unit testing
-     */
-    public function push_last_login_to_message_queue($user_ID) {
-        $last_login = $this->get_last_login($user_ID) ?: time();
-        $date_value  = date_i18n( "F j, Y g:i a T", $last_login, true );
-        $message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
-        ###$this->log(__FUNCTION__, $message);
-        $this->add_to_message_queue($message);
-        return $this->set_last_login($user_ID);
-    }
+	/**
+	 * Adds new last login message to users message queue
+	 *
+	 * @param int $user_ID  the current user's ID number
+	 * @return mixed  return values provided for unit testing
+	 */
+	public function push_last_login_to_message_queue($user_ID) {
+		$last_login = $this->get_last_login($user_ID) ?: time();
+		$date_value  = date_i18n( "F j, Y g:i a T", $last_login, true );
+		$message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
+		###$this->log(__FUNCTION__, $message);
+		$this->add_to_message_queue($message);
+		return $this->set_last_login($user_ID);
+	}
 
 	/**
 	 * Declares our password policy gettext filter and deactivates the
@@ -1173,15 +1173,15 @@ class login_security_solution {
 		return (int) get_user_meta($user_ID, $this->umk_last_active, true);
 	}
 
-    /**
-     * Obtains the timestamp of the given user's last login on the site
-     *
-     * @param int $user_ID  the current user's ID number
-     * @return int  the Unix timestamp of the user's last login
-     */
-    protected function get_last_login($user_ID) {
-        return (int) get_user_meta($user_ID, $this->umk_last_login, true);
-    }
+	/**
+	 * Obtains the timestamp of the given user's last login on the site
+	 *
+	 * @param int $user_ID  the current user's ID number
+	 * @return int  the Unix timestamp of the user's last login
+	 */
+	protected function get_last_login($user_ID) {
+		return (int) get_user_meta($user_ID, $this->umk_last_login, true);
+	}
 
 
 	/**
@@ -1241,20 +1241,20 @@ class login_security_solution {
 		return $result;
 	}
 
-    /**
-     * Gets the users message queue
-     *
-     * return array the message queue
-     */
-    protected function get_message_queue($user_ID) {
-        $message_queue = get_user_meta($user_ID, $this->umk_message_queue, true);
-        if (empty($message_queue)) {
-            $message_queue = array();
-        } elseif (!is_array($message_queue)) {
-            $message_queue = (array) $message_queue;
-        }
-        return $message_queue;
-    }
+	/**
+	 * Gets the users message queue
+	 *
+	 * return array the message queue
+	 */
+	protected function get_message_queue($user_ID) {
+		$message_queue = get_user_meta($user_ID, $this->umk_message_queue, true);
+		if (empty($message_queue)) {
+			$message_queue = array();
+		} elseif (!is_array($message_queue)) {
+			$message_queue = (array) $message_queue;
+		}
+		return $message_queue;
+	}
 
 	/**
 	 * Gets the "network" component of an IP address
@@ -2432,7 +2432,7 @@ Password MD5                 %5d     %s
 			delete_user_meta($user->ID, $this->umk_last_active);
 		}
 
-        $this->push_last_login_to_message_queue($user->ID);
+		$this->push_last_login_to_message_queue($user->ID);
 
 		$flag = 1;
 		$ip = $this->get_ip();
@@ -2681,16 +2681,16 @@ Password MD5                 %5d     %s
 		return update_user_meta($user_ID, $this->umk_last_active, time());
 	}
 
-    /**
-     * Stores the present time in the given user's "last login" metadata
-     *
-     * @param int $user_ID  the current user's ID number
-     * @return int|bool  the record number if added, TRUE if updated, FALSE
-     *                   if error
-     */
-    protected function set_last_login($user_ID) {
-        return update_user_meta($user_ID, $this->umk_last_login, time());
-    }
+	/**
+	 * Stores the present time in the given user's "last login" metadata
+	 *
+	 * @param int $user_ID  the current user's ID number
+	 * @return int|bool  the record number if added, TRUE if updated, FALSE
+	 *                   if error
+	 */
+	protected function set_last_login($user_ID) {
+		return update_user_meta($user_ID, $this->umk_last_login, time());
+	}
 
 	/**
 	 * Replaces the default option values with those stored in the database

--- a/tests/LastLoginTest.php
+++ b/tests/LastLoginTest.php
@@ -28,6 +28,9 @@ class LastLoginTest extends TestCase {
 		$this->assertSame(0, $actual);
 	}
 
+	/**
+	 * @depends test_get_last_login__empty_1
+	 */
 	public function test_set_last_login__add() {
 		$actual = self::$lss->set_last_login($this->user->ID);
 		$this->assertInternalType('integer', $actual, 'Bad return value.');
@@ -52,12 +55,12 @@ class LastLoginTest extends TestCase {
 		$this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
 	}
 
-
+	/**
+	 * @depends test_get_last_login__empty_1
+	 */
 	public function test_add_to_message_queue__add() {
-		global $user_ID;
-		$user_ID = $this->user->ID;
 		$message = 'foo';
-		$actual = self::$lss->add_to_message_queue($message);
+		$actual = self::$lss->add_to_message_queue($message, $this->user->ID);
 		$this->assertInternalType('integer', $actual, 'Bad return value.');
 	}
 
@@ -67,7 +70,7 @@ class LastLoginTest extends TestCase {
 	public function test_add_to_message_queue__update() {
 		sleep(1);
 		$message = 'bar';
-		$actual = self::$lss->add_to_message_queue($message);
+		$actual = self::$lss->add_to_message_queue($message, $this->user->ID);
 		$this->assertTrue($actual, 'Bad return value.');
 	}
 
@@ -75,6 +78,8 @@ class LastLoginTest extends TestCase {
 	 * @depends test_add_to_message_queue__update
 	 */
 	public function test_display_admin_notices__display() {
+		global $user_ID;
+		$user_ID = $this->user->ID;
 		sleep(1);
 		$queue = (array) get_user_meta($this->user->ID, self::$lss->umk_message_queue);
 		$this->assertSame(2, count($queue[0]));

--- a/tests/LastLoginTest.php
+++ b/tests/LastLoginTest.php
@@ -14,109 +14,109 @@ require_once dirname(__FILE__) .  '/TestCase.php';
  * @license http://www.gnu.org/licenses/gpl-2.0.html GPLv2
  */
 class LastLoginTest extends TestCase {
-    protected static $user_ID;
+	protected static $user_ID;
 
 
-    public static function setUpBeforeClass() {
-        parent::$db_needed = true;
-        parent::set_up_before_class();
-    }
+	public static function setUpBeforeClass() {
+		parent::$db_needed = true;
+		parent::set_up_before_class();
+	}
 
 
-    public function test_get_last_login__empty_1() {
-        $actual = self::$lss->get_last_login($this->user->ID);
-        $this->assertSame(0, $actual);
-    }
+	public function test_get_last_login__empty_1() {
+		$actual = self::$lss->get_last_login($this->user->ID);
+		$this->assertSame(0, $actual);
+	}
 
-    public function test_set_last_login__add() {
-        $actual = self::$lss->set_last_login($this->user->ID);
-        $this->assertInternalType('integer', $actual, 'Bad return value.');
-    }
+	public function test_set_last_login__add() {
+		$actual = self::$lss->set_last_login($this->user->ID);
+		$this->assertInternalType('integer', $actual, 'Bad return value.');
+	}
 
-    /**
-     * @depends test_set_last_login__add
-     */
-    public function test_set_last_login__update() {
-        sleep(1);
-        $actual = self::$lss->set_last_login($this->user->ID);
-        $this->assertTrue($actual, 'Bad return value.');
-    }
+	/**
+	 * @depends test_set_last_login__add
+	 */
+	public function test_set_last_login__update() {
+		sleep(1);
+		$actual = self::$lss->set_last_login($this->user->ID);
+		$this->assertTrue($actual, 'Bad return value.');
+	}
 
-    /**
-     * @depends test_set_last_login__update
-     */
-    public function test_get_last_login__something() {
-        $actual = self::$lss->get_last_login($this->user->ID);
-        $diff = (time() - $actual) < 1;
-        $this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
-        $this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
-    }
+	/**
+	 * @depends test_set_last_login__update
+	 */
+	public function test_get_last_login__something() {
+		$actual = self::$lss->get_last_login($this->user->ID);
+		$diff = (time() - $actual) < 1;
+		$this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
+		$this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
+	}
 
 
-    public function test_add_to_message_queue__add() {
-        global $user_ID;
-        $user_ID = $this->user->ID;
-        $message = 'foo';
-        $actual = self::$lss->add_to_message_queue($message);
-        $this->assertInternalType('integer', $actual, 'Bad return value.');
-    }
+	public function test_add_to_message_queue__add() {
+		global $user_ID;
+		$user_ID = $this->user->ID;
+		$message = 'foo';
+		$actual = self::$lss->add_to_message_queue($message);
+		$this->assertInternalType('integer', $actual, 'Bad return value.');
+	}
 
-    /**
-     * @depends test_add_to_message_queue__add
-     */
-    public function test_add_to_message_queue__update() {
-        sleep(1);
-        $message = 'bar';
-        $actual = self::$lss->add_to_message_queue($message);
-        $this->assertTrue($actual, 'Bad return value.');
-    }
+	/**
+	 * @depends test_add_to_message_queue__add
+	 */
+	public function test_add_to_message_queue__update() {
+		sleep(1);
+		$message = 'bar';
+		$actual = self::$lss->add_to_message_queue($message);
+		$this->assertTrue($actual, 'Bad return value.');
+	}
 
-    /**
-     * @depends test_add_to_message_queue__update
-     */
-    public function test_display_admin_notices__display() {
-        sleep(1);
-        $queue = (array) get_user_meta($this->user->ID, self::$lss->umk_message_queue);
-        $this->assertSame(2, count($queue[0]));
-        $actual = self::$lss->display_admin_notices_in_queue();
-        $test_data = '<div class="updated"><p>foo</p></div><div class="updated"><p>bar</p></div>';
-        $this->assertSame($test_data, $actual);
-    }
+	/**
+	 * @depends test_add_to_message_queue__update
+	 */
+	public function test_display_admin_notices__display() {
+		sleep(1);
+		$queue = (array) get_user_meta($this->user->ID, self::$lss->umk_message_queue);
+		$this->assertSame(2, count($queue[0]));
+		$actual = self::$lss->display_admin_notices_in_queue();
+		$test_data = '<div class="updated"><p>foo</p></div><div class="updated"><p>bar</p></div>';
+		$this->assertSame($test_data, $actual);
+	}
 
-    /**
-     * @depends test_display_admin_notices__display
-     */
-    public function test_display_admin_notices__delete_queue() {
-        sleep(1);
-        $actual = self::$lss->get_message_queue($this->user->ID);
-        $this->assertSame(0, count($actual));
-    }
+	/**
+	 * @depends test_display_admin_notices__display
+	 */
+	public function test_display_admin_notices__delete_queue() {
+		sleep(1);
+		$actual = self::$lss->get_message_queue($this->user->ID);
+		$this->assertSame(0, count($actual));
+	}
 
-    /**
-     * @depends test_set_last_login__update
-     */
-    public function test_push_last_login_to_message_queue__adds_message() {
-        $time = self::$lss->get_last_login($this->user->ID);
-        $date_value  = date_i18n( "F j, Y g:i a T", $time, true );
-        $expected_message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
-        $actual = self::$lss->push_last_login_to_message_queue($this->user->ID);
-        $this->assertTrue($actual, 'Bad return value.');
-        $message_queue = self::$lss->get_message_queue($this->user->ID);
-        $this->assertSame(1, count($message_queue));
-        $this->assertSame($expected_message, $message_queue[0]);
-    }
+	/**
+	 * @depends test_set_last_login__update
+	 */
+	public function test_push_last_login_to_message_queue__adds_message() {
+		$time = self::$lss->get_last_login($this->user->ID);
+		$date_value  = date_i18n( "F j, Y g:i a T", $time, true );
+		$expected_message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
+		$actual = self::$lss->push_last_login_to_message_queue($this->user->ID);
+		$this->assertTrue($actual, 'Bad return value.');
+		$message_queue = self::$lss->get_message_queue($this->user->ID);
+		$this->assertSame(1, count($message_queue));
+		$this->assertSame($expected_message, $message_queue[0]);
+	}
 
-    /**
-     * @depends test_push_last_login_to_message_queue__adds_message
-     */
-    public function test_push_last_login_to_message_queue__update() {
-        $before_time = self::$lss->get_last_login($this->user->ID);
-        self::$lss->push_last_login_to_message_queue($this->user->ID);
-        $after_time = self::$lss->get_last_login($this->user->ID);
-        $diff = ($after_time - $before_time) < 1;
-        $this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
-        $this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
-    }
+	/**
+	 * @depends test_push_last_login_to_message_queue__adds_message
+	 */
+	public function test_push_last_login_to_message_queue__update() {
+		$before_time = self::$lss->get_last_login($this->user->ID);
+		self::$lss->push_last_login_to_message_queue($this->user->ID);
+		$after_time = self::$lss->get_last_login($this->user->ID);
+		$diff = ($after_time - $before_time) < 1;
+		$this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
+		$this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
+	}
 
 
 }

--- a/tests/LastLoginTest.php
+++ b/tests/LastLoginTest.php
@@ -102,7 +102,9 @@ class LastLoginTest extends TestCase {
 	 */
 	public function test_push_last_login_to_message_queue__adds_message() {
 		$time = self::$lss->get_last_login($this->user->ID);
-		$date_value  = date_i18n( "F j, Y g:i a T", $time, true );
+		$tz_string = get_option('timezone_string');
+		date_default_timezone_set($tz_string);
+		$date_value  = date( "F j, Y g:i a T", $time);
 		$expected_message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
 		$actual = self::$lss->push_last_login_to_message_queue($this->user->ID);
 		$this->assertTrue($actual, 'Bad return value.');

--- a/tests/LastLoginTest.php
+++ b/tests/LastLoginTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Get the class we will use for testing
+ */
+require_once dirname(__FILE__) .  '/TestCase.php';
+
+/**
+ * Test the last login and message functionality
+ *
+ * @package login-security-solution
+ * @author
+ * @copyright
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GPLv2
+ */
+class LastLoginTest extends TestCase {
+    protected static $user_ID;
+
+
+    public static function setUpBeforeClass() {
+        parent::$db_needed = true;
+        parent::set_up_before_class();
+    }
+
+
+    public function test_get_last_login__empty_1() {
+        $actual = self::$lss->get_last_login($this->user->ID);
+        $this->assertSame(0, $actual);
+    }
+
+    public function test_set_last_login__add() {
+        $actual = self::$lss->set_last_login($this->user->ID);
+        $this->assertInternalType('integer', $actual, 'Bad return value.');
+    }
+
+    /**
+     * @depends test_set_last_login__add
+     */
+    public function test_set_last_login__update() {
+        sleep(1);
+        $actual = self::$lss->set_last_login($this->user->ID);
+        $this->assertTrue($actual, 'Bad return value.');
+    }
+
+    /**
+     * @depends test_set_last_login__update
+     */
+    public function test_get_last_login__something() {
+        $actual = self::$lss->get_last_login($this->user->ID);
+        $diff = (time() - $actual) < 1;
+        $this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
+        $this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
+    }
+
+
+    public function test_add_to_message_queue__add() {
+        global $user_ID;
+        $user_ID = $this->user->ID;
+        $message = 'foo';
+        $actual = self::$lss->add_to_message_queue($message);
+        $this->assertInternalType('integer', $actual, 'Bad return value.');
+    }
+
+    /**
+     * @depends test_add_to_message_queue__add
+     */
+    public function test_add_to_message_queue__update() {
+        sleep(1);
+        $message = 'bar';
+        $actual = self::$lss->add_to_message_queue($message);
+        $this->assertTrue($actual, 'Bad return value.');
+    }
+
+    /**
+     * @depends test_add_to_message_queue__update
+     */
+    public function test_display_admin_notices__display() {
+        sleep(1);
+        $queue = (array) get_user_meta($this->user->ID, self::$lss->umk_message_queue);
+        $this->assertSame(2, count($queue[0]));
+        $actual = self::$lss->display_admin_notices_in_queue();
+        $test_data = '<div class="updated"><p>foo</p></div><div class="updated"><p>bar</p></div>';
+        $this->assertSame($test_data, $actual);
+    }
+
+    /**
+     * @depends test_display_admin_notices__display
+     */
+    public function test_display_admin_notices__delete_queue() {
+        sleep(1);
+        $actual = self::$lss->get_message_queue($this->user->ID);
+        $this->assertSame(0, count($actual));
+    }
+
+    /**
+     * @depends test_set_last_login__update
+     */
+    public function test_push_last_login_to_message_queue__adds_message() {
+        $time = self::$lss->get_last_login($this->user->ID);
+        $date_value  = date_i18n( "F j, Y g:i a T", $time, true );
+        $expected_message = sprintf(__("Welcome back. Last logged in %s", self::ID), $date_value);
+        $actual = self::$lss->push_last_login_to_message_queue($this->user->ID);
+        $this->assertTrue($actual, 'Bad return value.');
+        $message_queue = self::$lss->get_message_queue($this->user->ID);
+        $this->assertSame(1, count($message_queue));
+        $this->assertSame($expected_message, $message_queue[0]);
+    }
+
+    /**
+     * @depends test_push_last_login_to_message_queue__adds_message
+     */
+    public function test_push_last_login_to_message_queue__update() {
+        $before_time = self::$lss->get_last_login($this->user->ID);
+        self::$lss->push_last_login_to_message_queue($this->user->ID);
+        $after_time = self::$lss->get_last_login($this->user->ID);
+        $diff = ($after_time - $before_time) < 1;
+        $this->assertGreaterThanOrEqual(0,  $diff, 'Time was too long ago.');
+        $this->assertLessThanOrEqual(1, $diff, 'Time was in the future.');
+    }
+
+
+}


### PR DESCRIPTION
This allows for fulfilling the requirements in [NIST 800-53](http://en.wikipedia.org/wiki/NIST_Special_Publication_800-53), Control AC-9 as required by some US Federal government agencies.

This control specifies:

> The information system notifies the user, upon successful logon (access), 
> of the date and time of the last logon (access).
