### PR TITLE
Feature/Automatic disabling of accounts after # of failed logins

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -288,6 +288,18 @@ class login_security_solution_admin extends login_security_solution {
 				'text' => sprintf(__("How many matching login failures should it take to get into this (%d - %d second) Delay Tier? Must be > Delay Tier 2.", self::ID), 25, 60),
 				'type' => 'int',
 			),
+			'login_fail_templock_user' => array(
+				'group' => 'login',
+				'label' => __("Temporarily Lock User", self::ID),
+				'text' => __("How many matching login failures should it take to temporarily lock the user account? 0 disables this feature.", self::ID),
+				'type' => 'int',
+			),
+			'login_fail_templock_time' => array(
+				'group' => 'login',
+				'label' => __("Temporary Lock Time", self::ID),
+				'text' => __("How long should the user account be temporarily locked?", self::ID),
+				'type' => 'int',
+			),
 			'login_fail_disable_user' => array(
 				'group' => 'login',
 				'label' => __("Disable User", self::ID),

--- a/admin.php
+++ b/admin.php
@@ -272,7 +272,7 @@ class login_security_solution_admin extends login_security_solution {
 			'login_fail_minutes' => array(
 				'group' => 'login',
 				'label' => __("Match Time", self::ID),
-				'text' => __("How far back, in minutes, should login failures look for matching data? 0 disables Login Failure slow downs, notifications and breach confirmations.", self::ID),
+				'text' => __("How far back, in minutes, should login failures look for matching data? 0 disables Login Failure slow downs, disabling accounts, notifications and breach confirmations.", self::ID),
 				'type' => 'int',
 			),
 			'login_fail_tier_2' => array(
@@ -286,6 +286,12 @@ class login_security_solution_admin extends login_security_solution {
 				'group' => 'login',
 				'label' => __("Delay Tier 3", self::ID),
 				'text' => sprintf(__("How many matching login failures should it take to get into this (%d - %d second) Delay Tier? Must be > Delay Tier 2.", self::ID), 25, 60),
+				'type' => 'int',
+			),
+			'login_fail_disable_user' => array(
+				'group' => 'login',
+				'label' => __("Disable User", self::ID),
+				'text' => __("How many matching login failures should it take to disable the user account? 0 disables this feature.", self::ID),
 				'type' => 'int',
 			),
 			'admin_email' => array(

--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -148,6 +148,8 @@ class login_security_solution {
 		'login_fail_minutes' => 120,
 		'login_fail_tier_2' => 5,
 		'login_fail_tier_3' => 10,
+		'login_fail_templock_user' => 0,
+		'login_fail_templock_time' => 30,
 		'login_fail_disable_user' => 0,
 		'login_fail_notify' => 50,
 		'login_fail_notify_multiple' => 0,
@@ -219,6 +221,12 @@ class login_security_solution {
 	 * @var string
 	 */
 	protected $umk_verified_ips;
+
+	/**
+	 * Our usermeta key for tracking when this users account was temporarily locked
+	 * @var bool
+	 */
+	protected $umk_locked_time;
 
 	/**
 	 * Our usermeta key for tracking if this user account is disabled
@@ -345,6 +353,7 @@ class login_security_solution {
 		$this->umk_hashes = self::ID . '-pw-hashes';
 		$this->umk_last_active = self::ID . '-last-active';
 		$this->umk_verified_ips = self::ID . '-verified-ips';
+		$this->umk_locked_time = self::ID . '-lock-time';
 		$this->umk_disabled_account = self::ID . '-disabled-account';
 
 		$this->dir_dictionaries = dirname(__FILE__) . '/pw_dictionaries/';
@@ -529,6 +538,13 @@ class login_security_solution {
 			}
 		}
 
+		if ($this->is_account_locked($user->ID)) {
+			if (!$this->is_xmlrpc) {
+				$this->redirect_to_login('account_locked', true);
+			}
+			return -8;
+		}
+
 		if ($this->is_account_disabled($user->ID)) {
 			if (!$this->is_xmlrpc) {
 				$this->redirect_to_login('account_disabled', true);
@@ -695,6 +711,10 @@ class login_security_solution {
 				case 'idle':
 					$ours = sprintf(__('It has been over %d minutes since your last action.', self::ID), $this->options['idle_timeout']);
 					$ours .= ' ' . __('Please log back in.', self::ID);
+					break;
+				case 'account_locked':
+					$ours = __('Your account has been temporarily locked.', self::ID);
+					$ours = ' ' . sprintf(__('You can login again in approximately %d minutes', self::ID), $this->options['login_fail_templock_time']);
 					break;
 				case 'account_disabled':
 					$ours = __('Your account has been disabled.', self::ID);
@@ -1109,6 +1129,16 @@ class login_security_solution {
 	}
 
 	/**
+	 * Obtains the timestamp of the locked time on users account
+	 *
+	 * @param int $user_ID  the current user's ID number
+	 * @return int  the Unix timestamp of the user's lockout time
+	 */
+	protected function get_lockout_time($user_ID) {
+		return (int) get_user_meta($user_ID, $this->umk_locked_time, true);
+	}
+
+	/**
 	 * Obtains the number of login failures for the current IP, user name
 	 * and password in the period specified by login_fail_minutes
 	 *
@@ -1504,6 +1534,27 @@ Password MD5                 %5d     %s
 		if ($this->get_user_account_disabled($user_ID) == '1') {
 			return true;
 		}
+		return false;
+	}
+
+	/**
+	 * Is the user account locked?
+	 * @param in $user_ID  the user's id number
+	 * @return bool  true if account is temporarily locked
+	 */
+	public function is_account_locked($user_ID) {
+		if (!$this->options['login_fail_templock_user']) {
+			return null;
+		}
+
+		$lockout_time = $this->get_lockout_time($user_ID);
+		if ( ! $lockout_time ) {
+			return false;
+		}
+		if (($this->options['login_fail_templock_time'] * 60) + $lockout_time > time()) {
+			return true;
+		}
+		delete_user_meta($user_ID, $this->umk_locked_time);
 		return false;
 	}
 
@@ -2306,6 +2357,18 @@ Password MD5                 %5d     %s
 			return -4;
 		}
 
+		if ($this->options['login_fail_templock_user']
+			&& ($fails['total'] == $this->options['login_fail_templock_user'])) {
+
+			$this->log(__FUNCTION__, "Trying to get user to lock");
+			$user = get_user_by('login', $user_name);
+			$this->log(__FUNCTION__, $user->ID);
+			if ($user) {
+				$this->log(__FUNCTION__, "Locking user: " . $user_name . ' ID: ' . $user->ID);
+				$this->set_lockout_time($user->ID);
+			}
+		}
+
 		if ($this->options['login_fail_disable_user']
 			&& ($fails['total'] == $this->options['login_fail_disable_user'])) {
 
@@ -2621,6 +2684,17 @@ Password MD5                 %5d     %s
 	 */
 	protected function set_user_account_disabled($user_ID) {
 		return update_user_meta($user_ID, $this->umk_disabled_account, 1);
+	}
+
+	/**
+	 * Stores the present time in the given user's "locked time" metadata
+	 *
+	 * @param int $user_ID  the current user's ID number
+	 * @return int|bool  the record number if added, TRUE if updated, FALSE
+	 *                   if error
+	 */
+	protected function set_lockout_time($user_ID) {
+		return update_user_meta($user_ID, $this->umk_locked_time, time());
 	}
 
 	/**

--- a/tests/LoginFailTest.php
+++ b/tests/LoginFailTest.php
@@ -62,6 +62,8 @@ class LoginFailTest extends TestCase {
 		$options['login_fail_notify_multiple'] = 0;
 		$options['login_fail_tier_2'] = 3;
 		$options['login_fail_tier_3'] = 4;
+		$options['login_fail_templock_user'] = 3;
+		$options['login_fail_templock_time'] = 30;
 		$options['login_fail_disable_user'] = 3;
 		$options['login_fail_breach_notify'] = 4;
 		$options['login_fail_breach_pw_force_change'] = 4;
@@ -172,6 +174,16 @@ class LoginFailTest extends TestCase {
 	/**
 	 * @depends test_get_login_fail
 	 */
+	public function test_process_login_fail__account_not_locked() {
+		// At this point, our user should not be disabled
+		$user = get_user_by('login', $this->user_name);
+		$disabled = self::$lss->is_account_locked($user->ID);
+		$this->assertFalse($disabled, 'Account should not be locked');
+	}
+
+	/**
+	 * @depends test_get_login_fail
+	 */
 	public function test_process_login_fail__account_enabled() {
 		// At this point, our user should not be disabled
 		$user = get_user_by('login', $this->user_name);
@@ -190,6 +202,18 @@ class LoginFailTest extends TestCase {
 
 		$this->assertInternalType('integer', $wpdb->insert_id,
 				'This should be an insert id.');
+	}
+
+	/**
+	 * @depends test_process_login_fail__pre_threshold
+	 */
+	public function test_process_login_fail__account_locked() {
+		// test_process_login_fail__pre_threshold should have triggered our
+		// limit and disabled the user
+		sleep(1);
+		$user = get_user_by('login', $this->user_name);
+		$disabled = self::$lss->is_account_locked($user->ID);
+		$this->assertTrue($disabled, 'Account should be locked' );
 	}
 
 	/**

--- a/tests/LoginMessageTest.php
+++ b/tests/LoginMessageTest.php
@@ -71,6 +71,22 @@ class LoginMessageTest extends TestCase {
 				'Output should have been modified.');
 	}
 
+	public function test_login_message__account_locked() {
+		$_GET[self::$lss->key_login_msg] = 'account_locked';
+
+		$value = 13;
+		$options = self::$lss->options;
+		$options['login_fail_templock_time'] = $value;
+		self::$lss->options = $options;
+
+		$ours = __('Your account has been temporarily locked.', self::ID);
+		$ours = ' ' . sprintf(__('You can login again in approximately %d minutes', self::ID), $value);
+
+		$actual = self::$lss->login_message('input');
+		$this->assertEquals('input' . $this->ours($ours), $actual,
+				'Output should have been modified.');
+	}
+
 	public function test_login_message__account_disabled() {
 		$_GET[self::$lss->key_login_msg] = 'account_disabled';
 

--- a/tests/LoginMessageTest.php
+++ b/tests/LoginMessageTest.php
@@ -71,6 +71,17 @@ class LoginMessageTest extends TestCase {
 				'Output should have been modified.');
 	}
 
+	public function test_login_message__account_disabled() {
+		$_GET[self::$lss->key_login_msg] = 'account_disabled';
+
+		$ours = __('Your account has been disabled.', self::ID);
+		$ours .= ' ' . __('Please contact your administrator to re-enable your account.', self::ID);
+
+		$actual = self::$lss->login_message('input');
+		$this->assertEquals('input' . $this->ours($ours), $actual,
+				'Output should have been modified.');
+	}
+
 	public function test_login_message__pw_expired() {
 		$_GET[self::$lss->key_login_msg] = 'pw_expired';
 


### PR DESCRIPTION
This address [NIST 800-53](http://en.wikipedia.org/wiki/NIST_Special_Publication_800-53) Control AC-7 requirements that are currently missing, specifically, automatic disabling of the account, and allowing the Administrator to manually re-enable the account. The delay tiers that are currently built-in satisfy the other requirements.

The control specifies:

> a. Enforces a limit of [Assignment: organization-defined number] consecutive invalid login 
> attempts by a user during a [Assignment: organization-defined time period]; and
> b. Automatically [Selection: locks the account/node for an [Assignment: organization-defined 
> time period]; locks the account/node until released by an administrator; delays next login 
> prompt according to [Assignment: organization-defined delay algorithm]] when the 
> maximum number of unsuccessful attempts is exceeded. The control applies regardless of 
> whether the login occurs via a local or network connection.
