### PR TITLE
Calling `login_security_solution_notify_fail` hook at the end of `notify_...

### DIFF
--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -2224,6 +2224,15 @@ Password MD5                 %5d     %s
 			$message .= "\n" . sprintf(__("Further notifications about this attacker will only be sent if the attack stops for at least %d minutes and then resumes.", self::ID), $this->options['login_fail_minutes']) . "\n";
 		}
 
+		$action_args = array(
+			'ip' => $ip,
+			'user_name' => $user_name,
+			'pass_md5' => $pass_md5,
+			'fails' => $fails,
+			'options' => $this->options
+		);
+		do_action( 'login_security_solution_notify_fail', $action_args );
+
 		return wp_mail($to, $subject, $message);
 	}
 


### PR DESCRIPTION
...fail()` method (and passing an array to it).

The argument passed to the hooked function is an array containing: `ip`, `user_name`, `pass_md5`, `fails` and `options` keys.

This comes in handy when one wants to do additional actions (besides getting notified via email) when a "we're under attack" condition occurs. I use it to ban IPs and do some other things (based on the other data being sent to the hook).

This is just a refresh of #24 based on the latest release (0.45.0).
