### PR TITLE
allow activation network-wide only on multisite

### DIFF
--- a/login-security-solution.php
+++ b/login-security-solution.php
@@ -11,6 +11,7 @@
  * Author: Daniel Convissor
  * Author URI: http://www.analysisandsolutions.com/
  * License: GPLv2
+ * Network: true
  * @package login-security-solution
  */
 


### PR DESCRIPTION
Use core functionality to limit activation on multisite to network-wide
